### PR TITLE
[Refactor #25] 웨디카이브 수정

### DIFF
--- a/weady/weady/Sources/Feature/Weadychive/Views/DeleteView.swift
+++ b/weady/weady/Sources/Feature/Weadychive/Views/DeleteView.swift
@@ -1,0 +1,125 @@
+//
+//  DeleteView.swift
+//  weady
+//
+//  Created by 고석현 on 7/28/25.
+//
+
+import SwiftUI
+
+enum DeleteContentType {
+    case curation, weadyboard
+
+    var title: String {
+        switch self {
+        case .curation: return "스크랩한 큐레이션"
+        case .weadyboard: return "스크랩한 웨디보드"
+        }
+    }
+
+    var gridColumns: [GridItem] {
+        switch self {
+        case .curation: return Array(repeating: GridItem(.flexible(), spacing: 2), count: 2)
+        case .weadyboard: return Array(repeating: GridItem(.flexible(), spacing: 2), count: 3)
+        }
+    }
+
+    func imageName(for index: Int) -> String {
+        switch self {
+        case .curation: return index % 2 == 0 ? "curation1" : "curation2"
+        case .weadyboard: return "weadyboard\((index % 7) + 1)"
+        }
+    }
+
+    var imageHeight: CGFloat {
+        switch self {
+        case .curation: return 240
+        case .weadyboard: return 164
+        }
+    }
+}
+
+//MARK: -스크랩 취소하기 화면
+struct DeleteView: View {
+    @Environment(\.dismiss) var dismiss
+    let type: DeleteContentType
+    @Binding var items: [Int]
+    var onDelete: ([Int]) -> Void
+    @State private var selectedItems: Set<Int> = []
+
+   
+    var body: some View {
+        VStack(spacing: 0) {
+
+
+            ScrollView {
+                LazyVGrid(columns: type.gridColumns, spacing: 2) {
+                    // 삭제 가능한 항목 리스트 표시
+                    ForEach(items, id: \.self) { index in
+                        Button {
+                            if selectedItems.contains(index) {
+                                selectedItems.remove(index)
+                            } else {
+                                selectedItems.insert(index)
+                            }
+                        } label: {
+                            ZStack(alignment: .topTrailing) {
+                                Image(type.imageName(for: index))
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(height: type.imageHeight)
+                                    .clipped()
+                                    .overlay(
+                                        selectedItems.contains(index) ? Color.black.opacity(0.3) : Color.clear
+                                    )
+
+                                Image(systemName: selectedItems.contains(index) ? "checkmark.circle.fill" : "circle")
+                                    .resizable()
+                                    .frame(width: 24, height: 24)
+                                    .foregroundStyle(.white)
+                                    .background(Color.black.opacity(0.6))
+                                    .clipShape(Circle())
+                                    .padding(6)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 2)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {
+                    dismiss()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundStyle(.black)
+                }
+            }
+
+            ToolbarItem(placement: .principal) {
+                Text("취소할 항목")
+                    .font(.headline)
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    dismiss()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        onDelete(Array(selectedItems))
+                    }
+                }) {
+                    Text("완료")
+                        .fontName(.captionMedium14)
+                        .foregroundStyle(.black)
+                }
+            }
+        }
+    }
+}
+
+
+
+

--- a/weady/weady/Sources/Feature/Weadychive/Views/NoCurationView.swift
+++ b/weady/weady/Sources/Feature/Weadychive/Views/NoCurationView.swift
@@ -1,0 +1,41 @@
+//
+//  NoCurationView.swift
+//  weady
+//
+//  Created by 고석현 on 7/28/25.
+//
+
+import SwiftUI
+
+// MARK: - NoCurationView (스크랩된 큐레이션 없는 경우)
+struct NoCurationView: View {
+    var body: some View {
+        VStack {
+            VStack(spacing:20) {
+                Text("추천 큐레이션에서 마음에 드는 하루를 담아보세요!")
+                    .fontName(.metaMedium12)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                Button(action: {
+                    // TODO: - 큐레이션 탐색 화면으로 이동
+                    //CurationView()
+                }) {
+                    Text("큐레이션 보러가기")
+                        .fontName(.captionSemibold14)
+                        .foregroundStyle(.white)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 20)
+                        .background(Color.gray900)
+                        .cornerRadius(8)
+                }
+            }
+            .padding(.top, 141)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+

--- a/weady/weady/Sources/Feature/Weadychive/Views/NoWeadyboardView.swift
+++ b/weady/weady/Sources/Feature/Weadychive/Views/NoWeadyboardView.swift
@@ -1,0 +1,43 @@
+//
+//  NoWeadyboardView.swift
+//  weady
+//
+//  Created by 고석현 on 7/28/25.
+//
+
+import SwiftUI
+
+// MARK: - NoWeadyboardView (스크랩된 웨디보드 없는 경우)
+struct NoWeadyboardView: View {
+    var body: some View {
+        VStack {
+            VStack(spacing: 20) {
+                Text("웨디보드에서는 다른 사람의 하루도 아카이빙할 수 있어요!")
+                    .fontName(.metaMedium12)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                Button(action: {
+                    // TODO: - 웨디보드 탐색 화면으로 이동
+                    //WeadyboardView()
+                }) {
+                    Text("웨디보드 보러가기")
+                        .fontName(.captionSemibold14)
+                        .foregroundStyle(.white)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 20)
+                        .background(Color.gray900)
+                        .cornerRadius(8)
+                }
+            }
+            .padding(.top, 141)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+#Preview {
+    NoWeadyboardView()
+}

--- a/weady/weady/Sources/Feature/Weadychive/Views/WeadychiveView.swift
+++ b/weady/weady/Sources/Feature/Weadychive/Views/WeadychiveView.swift
@@ -18,7 +18,7 @@ struct WeadychiveView: View {
     @State private var selectedTopTab: TopTab = .curation // 기본 선택 탭
     @State private var showSheet = false // 시트 표시 여부
     @State private var navigateToDeleteView: Bool = false   // 삭제 뷰로 네비게이션 여부
-    // Now managed by ViewModel
+
 
     // MARK: - Body
     var body: some View {
@@ -142,7 +142,7 @@ struct TopTabIndicatorView: View {
                                     .frame(height: 1)
                             }
                         }
-                        .frame(maxWidth: .infinity)  
+                        .frame(maxWidth: .infinity)
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -243,7 +243,7 @@ struct SheetView: View {
                 }
             } label: {
                 Text("스크랩 취소하기")
-                    .foregroundColor(Color(red: 1, green: 0.23, blue: 0.19)) //피그마에 맞는 시스템 레드로 바꿈
+                    .foregroundStyle(Color(red: 1, green: 0.23, blue: 0.19)) //피그마에 맞는 시스템 레드로 바꿈
                 //그냥 피그마에 있는 속성 그대로 가져옴. (extension에서 못찾음)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 20)
@@ -255,169 +255,10 @@ struct SheetView: View {
 }
 
 
-enum DeleteContentType {
-    case curation, weadyboard
-
-    var title: String {
-        switch self {
-        case .curation: return "스크랩한 큐레이션"
-        case .weadyboard: return "스크랩한 웨디보드"
-        }
-    }
-
-    var gridColumns: [GridItem] {
-        switch self {
-        case .curation: return Array(repeating: GridItem(.flexible(), spacing: 2), count: 2)
-        case .weadyboard: return Array(repeating: GridItem(.flexible(), spacing: 2), count: 3)
-        }
-    }
-
-    func imageName(for index: Int) -> String {
-        switch self {
-        case .curation: return index % 2 == 0 ? "curation1" : "curation2"
-        case .weadyboard: return "weadyboard\((index % 7) + 1)"
-        }
-    }
-
-    var imageHeight: CGFloat {
-        switch self {
-        case .curation: return 240
-        case .weadyboard: return 164
-        }
-    }
-}
-
-struct DeleteView: View {
-    @Environment(\.dismiss) var dismiss
-    let type: DeleteContentType
-    @Binding var items: [Int]
-    var onDelete: ([Int]) -> Void
-    @State private var selectedItems: Set<Int> = []
-
-   
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button { dismiss() } label: {
-                    Image(systemName: "chevron.left").foregroundStyle(.black)
-                }
-                Spacer()
-                Text("취소할 항목").font(.headline)
-                Spacer()
-                // 완료 버튼 탭 시: 뷰를 닫고 선택된 항목을 삭제
-                Text("완료")
-                    .fontName(.captionMedium14)
-                    .onTapGesture {
-                        dismiss()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            onDelete(Array(selectedItems))
-                        }
-                    }
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 16)
-
-            ScrollView {
-                LazyVGrid(columns: type.gridColumns, spacing: 2) {
-                    // 삭제 가능한 항목 리스트 표시
-                    ForEach(items, id: \.self) { index in
-                        ZStack(alignment: .topTrailing) {
-                            Image(type.imageName(for: index))
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(height: type.imageHeight)
-                                .clipped()
-                                .overlay(
-                                    selectedItems.contains(index) ? Color.black.opacity(0.3) : Color.clear
-                                )
-                            Button {
-                                if selectedItems.contains(index) {
-                                    selectedItems.remove(index)
-                                } else {
-                                    selectedItems.insert(index)
-                                }
-                            } label: {
-                                Image(systemName: selectedItems.contains(index) ? "checkmark.circle.fill" : "circle")
-                                    .resizable()
-                                    .frame(width: 24, height: 24)
-                                    .foregroundStyle(.white)
-                                    .background(Color.black.opacity(0.6))
-                                    .clipShape(Circle())
-                                    .padding(6)
-                            }
-                        }
-                    }
-                }
-                .padding(.horizontal, 2)
-            }
-        }
-        .navigationBarBackButtonHidden(true)
-    }
-}
 
 
 
 
-// MARK: - NoCurationView (스크랩된 큐레이션 없는 경우)
-struct NoCurationView: View {
-    var body: some View {
-        VStack {
-            VStack(spacing:20) {
-                Text("추천 큐레이션에서 마음에 드는 하루를 담아보세요!")
-                    .fontName(.metaMedium12)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
 
-                Button(action: {
-                    // TODO: - 큐레이션 탐색 화면으로 이동
-                    //WeadychiveView()
-                }) {
-                    Text("큐레이션 보러가기")
-                        .fontName(.captionSemibold14)
-                        .foregroundStyle(.white)
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 20)
-                        .background(Color.gray900)
-                        .cornerRadius(8)
-                }
-            }
-            .padding(.top, 141)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
-    }
-}
-
-// MARK: - NoWeadyboardView (스크랩된 웨디보드 없는 경우)
-struct NoWeadyboardView: View {
-    var body: some View {
-        VStack {
-            VStack(spacing: 20) {
-                Text("웨디보드에서는 다른 사람의 하루도 아카이빙할 수 있어요!")
-                    .fontName(.metaMedium12)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
-
-                Button(action: {
-                    // TODO: - 웨디보드 탐색 화면으로 이동
-                    //WeadyboardView()
-                }) {
-                    Text("웨디보드 보러가기")
-                        .fontName(.captionSemibold14)
-                        .foregroundStyle(.white)
-                        .padding(.vertical, 10)
-                        .padding(.horizontal, 20)
-                        .background(Color.gray900)
-                        .cornerRadius(8)
-                }
-            }
-            .padding(.top, 141)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
-    }
-}
 
 #Preview{WeadychiveView()}


### PR DESCRIPTION

## ✨ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
1. 스크랩 취소하기 화면에서 네비게이션 바를 HStack 에서 ToolBar 이용하는 방향으로 수정. (중앙 파트장님이 추천)
2. deprecated 수정자들 변경
3. 스크랩취소하기 화면에서 이미지위에 overlay되어있는 원 버튼 선택 뿐만이 아니라 이미지 선택시에도 선택되도록 변경.
4.하위 뷰들은 따로 분리.

- API  연동 이전 웨디카이브 화면 레이아웃은 완료..!
- 추후 서버와 연결 시 모델 파일 수정되면서 파일 구조 및 뷰 코드 변경 될 수 있음. 

## 📱 스크린샷
|기능|스크린샷|
|:--:|:--:|

|GIF|<img src = "https://github.com/user-attachments/assets/e65490d8-902a-44b5-9244-1ed2bf33b5d1" width ="250">|

## 📌 리뷰 포인트

## 관련 이슈
- Resolved: #25 
